### PR TITLE
Specify a CRX3 signed package in the download path to support Chrome version 73+

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -33,7 +33,7 @@ $(function(){
   }
 
   function buildDownloadLink(extensionId) {
-    var baseUrl = 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=49.0&x=id%3D***%26installsource%3Dondemand%26uc';
+    var baseUrl = 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=49.0&acceptformat=crx3&x=id%3D***%26installsource%3Dondemand%26uc';
     var replacer = '***';
     return baseUrl.replace(replacer, extensionId);
   }


### PR DESCRIPTION
CRX files downloaded using https://crxextractor.com/ fail to install for Chrome versions > 73 with the  error `CRX_HEADER_INVALID`. This is likely related to the bug report at https://bugs.chromium.org/p/chromium/issues/detail?id=941356

This PR adds an explicit `acceptformat` parameter to the download path to address a bug present for Chrome versions > 73. The default is typically CRX2 which is no longer supported by Chrome, so this changes the download path to point to a CRX3 signed package.